### PR TITLE
[Document] Add lstlisting package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ make clean
 
 ### Вставка исходного кода
 
-Для оформления листингов с исходным кодом используется окружение ```\begin{verbatim} ... \end{verbatim}```
+Для оформления листингов с исходным кодом используется окружение ```\begin{lstlisting} ... \end{lstlisting}```
 
 ```
-\begin{verbatim}
+\begin{lstlisting}
     #include <iostream>
 
     int main()
@@ -160,7 +160,7 @@ make clean
         std::cout << "hello, world!" << std::endl;
         return 0;
     }
-\end{verbatim}
+\end{lstlisting}
 ```
 
 ### Благодарности

--- a/include/preambule.tex
+++ b/include/preambule.tex
@@ -62,6 +62,12 @@
 \usepackage{float}   % Добавляет возможность работы с командой [H] которая улучшает расположение на странице
 \usepackage{gensymb} % Красивые градусы
 \usepackage{caption} % Пакет для подписей к рисункам, в частности, для работы caption*
+\usepackage{listings} % Пакет для листингов с кодом
+\lstset{              % Настройки для лисингов с кодом
+basicstyle=\small\ttfamily,
+columns=flexible,
+breaklines=true
+}
 
 % подключаем hyperref (для ссылок внутри  pdf)
 \usepackage[unicode, pdftex]{hyperref}


### PR DESCRIPTION
The `verbatim` package is inferior to `listings` package due to one issue: **breaking code lines**.
See example of code with `verbatim`:
![image](https://github.com/pavel-collab/Bachelor-Thesis-Template/assets/48734918/8087309a-da31-4acb-a9a8-51d2781c7535)

and with `lstlisting`:
![image](https://github.com/pavel-collab/Bachelor-Thesis-Template/assets/48734918/9e1297fb-cb31-4442-869d-2c775942296b)
